### PR TITLE
Feature/41 update readme

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,14 +37,14 @@ jobs:
         ./gradlew jacocoTestReport
         bash <(curl -s https://codecov.io/bash)
 
-    - name: Codecov Coverage Report
-      uses: codecov/codecov-action@v2
-      with:
-        files: ./build/reports/jacoco/test/jacocoTestReport.xml # optional
-        flags: unittest #optional
-        # name: codecov-umbrella # optional
-        fail_ci_if_error: true # optional (default = false)
-        verbose: true # optional (default = false)
+    # - name: Codecov Coverage Report
+    #   uses: codecov/codecov-action@v2
+    #   with:
+    #     files: ./build/reports/jacoco/test/jacocoTestReport.xml # optional
+    #     flags: unittest #optional
+    #     # name: codecov-umbrella # optional
+    #     fail_ci_if_error: true # optional (default = false)
+    #     verbose: true # optional (default = false)
 
   Docker-Integration-Test:
     needs: Unit-Test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Standard Tests Workflow
+name: Standard Tests
 on: [push, pull_request, workflow_dispatch] #workflow_dispatch works only if its active in the main branch
 jobs:
   Unit-Test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,15 +32,15 @@ jobs:
     - name: Running Tests
       run: "./gradlew test --tests=org.*"
 
-    # - name: After Success Submitting Code Coverage
-    #   run: | #jacocoTestReport is for testing code coverage, submits the last report to the link
-    #     ./gradlew jacocoTestReport
-    #     bash <(curl -s https://codecov.io/bash)
+    - name: After Success Submitting Code Coverage
+      run: | #jacocoTestReport is for testing code coverage, submits the last report to the link
+        ./gradlew jacocoTestReport
+        bash <(curl -s https://codecov.io/bash)
 
     - name: Codecov Coverage Report
       uses: codecov/codecov-action@v2
       with:
-        # files: ./coverage1.xml,./coverage2.xml # optional
+        files: ./build/reports # optional
         flags: unittest #optional
         # name: codecov-umbrella # optional
         fail_ci_if_error: true # optional (default = false)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Codecov Coverage Report
       uses: codecov/codecov-action@v2
       with:
-        files: ./build/reports/jacoco/test/html/jacocoTestReport.xml # optional
+        files: ./build/reports/jacoco/test/jacocoTestReport.xml # optional
         flags: unittest #optional
         # name: codecov-umbrella # optional
         fail_ci_if_error: true # optional (default = false)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,15 +38,13 @@ jobs:
     #     bash <(curl -s https://codecov.io/bash)
 
     - name: Codecov Coverage Report
-      steps:
-      - uses: actions/checkout@master
-      - uses: codecov/codecov-action@v2
-        with:
-          # files: ./coverage1.xml,./coverage2.xml # optional
-          flags: unittest #optional
-          # name: codecov-umbrella # optional
-          fail_ci_if_error: true # optional (default = false)
-          verbose: true # optional (default = false)
+    - uses: codecov/codecov-action@v2
+      with:
+        # files: ./coverage1.xml,./coverage2.xml # optional
+        flags: unittest #optional
+        # name: codecov-umbrella # optional
+        fail_ci_if_error: true # optional (default = false)
+        verbose: true # optional (default = false)
 
   Docker-Integration-Test:
     needs: Unit-Test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,17 +37,7 @@ jobs:
         ./gradlew jacocoTestReport
         bash <(curl -s https://codecov.io/bash)
 
-    # - name: Codecov Coverage Report
-    #   uses: codecov/codecov-action@v2
-    #   with:
-    #     files: ./build/reports/jacoco/test/jacocoTestReport.xml # optional
-    #     flags: unittest #optional
-    #     # name: codecov-umbrella # optional
-    #     fail_ci_if_error: true # optional (default = false)
-    #     verbose: true # optional (default = false)
-
   Docker-Integration-Test:
-    if: false
     needs: Unit-Test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,14 +37,14 @@ jobs:
         ./gradlew jacocoTestReport
         bash <(curl -s https://codecov.io/bash)
 
-    # - name: Codecov Coverage Report
-    #   uses: codecov/codecov-action@v2
-    #   with:
-    #     files: ./build/reports/jacoco/test/jacocoTestReport.xml # optional
-    #     flags: unittest #optional
-    #     # name: codecov-umbrella # optional
-    #     fail_ci_if_error: true # optional (default = false)
-    #     verbose: true # optional (default = false)
+    - name: Codecov Coverage Report
+      uses: codecov/codecov-action@v2
+      with:
+        files: ./build/reports/jacoco/test/jacocoTestReport.xml # optional
+        flags: unittest #optional
+        # name: codecov-umbrella # optional
+        fail_ci_if_error: true # optional (default = false)
+        verbose: true # optional (default = false)
 
   Docker-Integration-Test:
     needs: Unit-Test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,10 +32,10 @@ jobs:
     - name: Running Tests
       run: "./gradlew test --tests=org.*"
 
-    - name: After Success Submitting Code Coverage
-      run: | #jacocoTestReport is for testing code coverage, submits the last report to the link
-        ./gradlew jacocoTestReport
-        bash <(curl -s https://codecov.io/bash)
+    # - name: After Success Submitting Code Coverage
+    #   run: | #jacocoTestReport is for testing code coverage, submits the last report to the link
+    #     ./gradlew jacocoTestReport
+    #     bash <(curl -s https://codecov.io/bash)
 
     - name: Codecov Coverage Report
       uses: codecov/codecov-action@v2
@@ -45,7 +45,6 @@ jobs:
         # name: codecov-umbrella # optional
         fail_ci_if_error: true # optional (default = false)
         verbose: true # optional (default = false)
-        override_commit: 8bae75f
 
   Docker-Integration-Test:
     needs: Unit-Test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Codecov Coverage Report
       uses: codecov/codecov-action@v2
       with:
-        files: ./build/reports/*.xml # optional
+        files: ./build/reports/jacoco/test/html/index.html # optional
         flags: unittest #optional
         # name: codecov-umbrella # optional
         fail_ci_if_error: true # optional (default = false)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,10 +38,10 @@ jobs:
     #     bash <(curl -s https://codecov.io/bash)
     
     - name: Upload reports to Codecov
-        run: |
-          curl -Os https://uploader.codecov.io/latest/linux/codecov
-          chmod +x codecov
-          ./codecov -f coverage/codecov-result.json -Z
+      run: |
+        curl -Os https://uploader.codecov.io/latest/linux/codecov
+        chmod +x codecov
+        ./codecov -f coverage/codecov-result.json -Z
 
     # - name: Codecov Coverage Report
     #   uses: codecov/codecov-action@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,25 +32,19 @@ jobs:
     - name: Running Tests
       run: "./gradlew test --tests=org.*"
 
-    # - name: After Success Submitting Code Coverage
-    #   run: | #jacocoTestReport is for testing code coverage, submits the last report to the link
-    #     ./gradlew jacocoTestReport
-    #     bash <(curl -s https://codecov.io/bash)
-    
-    - name: Upload reports to Codecov
-      run: |
-        curl -Os https://uploader.codecov.io/latest/linux/codecov
-        chmod +x codecov
-        ./codecov -f coverage/codecov-result.json -Z
+    - name: After Success Submitting Code Coverage
+      run: | #jacocoTestReport is for testing code coverage, submits the last report to the link
+        ./gradlew jacocoTestReport
+        bash <(curl -s https://codecov.io/bash)
 
-    # - name: Codecov Coverage Report
-    #   uses: codecov/codecov-action@v2
-    #   with:
-    #     files: ./build/reports/jacoco/test/html/index.html # optional
-    #     flags: unittest #optional
-    #     # name: codecov-umbrella # optional
-    #     fail_ci_if_error: true # optional (default = false)
-    #     verbose: true # optional (default = false)
+    - name: Codecov Coverage Report
+      uses: codecov/codecov-action@v2
+      with:
+        files: ./build/reports/jacoco/test/html/jacocoTestReport.xml # optional
+        flags: unittest #optional
+        # name: codecov-umbrella # optional
+        fail_ci_if_error: true # optional (default = false)
+        verbose: true # optional (default = false)
 
   Docker-Integration-Test:
     needs: Unit-Test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,14 +37,14 @@ jobs:
         ./gradlew jacocoTestReport
         bash <(curl -s https://codecov.io/bash)
 
-    - name: Codecov Coverage Report
-      uses: codecov/codecov-action@v2
-      with:
-        files: ./build/reports/jacoco/test/html/index.html # optional
-        flags: unittest #optional
-        # name: codecov-umbrella # optional
-        fail_ci_if_error: true # optional (default = false)
-        verbose: true # optional (default = false)
+    # - name: Codecov Coverage Report
+    #   uses: codecov/codecov-action@v2
+    #   with:
+    #     files: ./build/reports/jacoco/test/html/index.html # optional
+    #     flags: unittest #optional
+    #     # name: codecov-umbrella # optional
+    #     fail_ci_if_error: true # optional (default = false)
+    #     verbose: true # optional (default = false)
 
   Docker-Integration-Test:
     needs: Unit-Test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,10 +32,16 @@ jobs:
     - name: Running Tests
       run: "./gradlew test --tests=org.*"
 
-    - name: After Success Submitting Code Coverage
-      run: | #jacocoTestReport is for testing code coverage, submits the last report to the link
-        ./gradlew jacocoTestReport
-        bash <(curl -s https://codecov.io/bash)
+    # - name: After Success Submitting Code Coverage
+    #   run: | #jacocoTestReport is for testing code coverage, submits the last report to the link
+    #     ./gradlew jacocoTestReport
+    #     bash <(curl -s https://codecov.io/bash)
+    
+    - name: Upload reports to Codecov
+        run: |
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          chmod +x codecov
+          ./codecov -f coverage/codecov-result.json -Z
 
     # - name: Codecov Coverage Report
     #   uses: codecov/codecov-action@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Codecov Coverage Report
       uses: codecov/codecov-action@v2
       with:
-        files: ./build/reports # optional
+        files: ./build/reports/*.xml # optional
         flags: unittest #optional
         # name: codecov-umbrella # optional
         fail_ci_if_error: true # optional (default = false)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,10 +32,10 @@ jobs:
     - name: Running Tests
       run: "./gradlew test --tests=org.*"
 
-    # - name: After Success Submitting Code Coverage
-    #   run: | #jacocoTestReport is for testing code coverage, submits the last report to the link
-    #     ./gradlew jacocoTestReport
-    #     bash <(curl -s https://codecov.io/bash)
+    - name: After Success Submitting Code Coverage
+      run: | #jacocoTestReport is for testing code coverage, submits the last report to the link
+        ./gradlew jacocoTestReport
+        bash <(curl -s https://codecov.io/bash)
 
     - name: Codecov Coverage Report
       uses: codecov/codecov-action@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
     #     bash <(curl -s https://codecov.io/bash)
 
     - name: Codecov Coverage Report
-    - uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v2
       with:
         # files: ./coverage1.xml,./coverage2.xml # optional
         flags: unittest #optional

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,16 +37,17 @@ jobs:
         ./gradlew jacocoTestReport
         bash <(curl -s https://codecov.io/bash)
 
-    - name: Codecov Coverage Report
-      uses: codecov/codecov-action@v2
-      with:
-        files: ./build/reports/jacoco/test/jacocoTestReport.xml # optional
-        flags: unittest #optional
-        # name: codecov-umbrella # optional
-        fail_ci_if_error: true # optional (default = false)
-        verbose: true # optional (default = false)
+    # - name: Codecov Coverage Report
+    #   uses: codecov/codecov-action@v2
+    #   with:
+    #     files: ./build/reports/jacoco/test/jacocoTestReport.xml # optional
+    #     flags: unittest #optional
+    #     # name: codecov-umbrella # optional
+    #     fail_ci_if_error: true # optional (default = false)
+    #     verbose: true # optional (default = false)
 
   Docker-Integration-Test:
+    if: false
     needs: Unit-Test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,10 +32,21 @@ jobs:
     - name: Running Tests
       run: "./gradlew test --tests=org.*"
 
-    - name: After Success Submitting Code Coverage
-      run: | #jacocoTestReport is for testing code coverage, submits the last report to the link
-        ./gradlew jacocoTestReport
-        bash <(curl -s https://codecov.io/bash)
+    # - name: After Success Submitting Code Coverage
+    #   run: | #jacocoTestReport is for testing code coverage, submits the last report to the link
+    #     ./gradlew jacocoTestReport
+    #     bash <(curl -s https://codecov.io/bash)
+
+    - name: Codecov Coverage Report
+      steps:
+      - uses: actions/checkout@master
+      - uses: codecov/codecov-action@v2
+        with:
+          # files: ./coverage1.xml,./coverage2.xml # optional
+          flags: unittest #optional
+          # name: codecov-umbrella # optional
+          fail_ci_if_error: true # optional (default = false)
+          verbose: true # optional (default = false)
 
   Docker-Integration-Test:
     needs: Unit-Test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,7 @@ jobs:
         # name: codecov-umbrella # optional
         fail_ci_if_error: true # optional (default = false)
         verbose: true # optional (default = false)
+        override_commit: 8bae75f
 
   Docker-Integration-Test:
     needs: Unit-Test

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+<img src="https://www.ga4gh.org/wp-content/themes/ga4gh-theme/gfx/GA-logo-horizontal-tag-RGB.svg" alt="GA4GH Logo" style="width: 400px;"/>
+
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
+[![Java 11+](https://img.shields.io/badge/java-11+-blue.svg?style=flat-square)](https://www.java.com)
+[![Gradle 7.3.3+](https://img.shields.io/badge/gradle-7.3.3+-blue.svg?style=flat-square)](https://gradle.org/)
+[![GitHub Actions](https://img.shields.io/github/workflow/status/ga4gh/ga4gh-starter-kit-common/Standard%20Tests/main)](https://github.com/ga4gh/ga4gh-starter-kit-common/actions)
+![Codecov](https://img.shields.io/codecov/c/github/ga4gh/ga4gh-starter-kit-common?style=flat-square)
+
 # GA4GH Starter Kit Common
 Common utils library for GA4GH Starter Kit web services
 

--- a/build.gradle
+++ b/build.gradle
@@ -135,3 +135,15 @@ nexusPublishing {
         sonatype()
     }
 }
+
+jacoco {
+    toolVersion = '0.8.5'
+    reportsDir = file("$buildDir/reports/jacoco")
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled = true
+        html.enabled = true
+    }
+}


### PR DESCRIPTION
- Added the methods to create the Jacoco Test Reports, which are submitted to Codecov, it is needed to create the badge.
- Changed the workflow name to be the same with starter-kit-drs, also its shorter and cleaner.
- Updated the README file to include the necessary badges

Note:
- The build badge is setup to get the build status for main, once the GitHub Actions workflow starts running in main it will start displaying correctly. [Proof](https://img.shields.io/github/workflow/status/ga4gh/ga4gh-starter-kit-common/Standard%20Tests).
- The Codecov badge needs a submitted report on the main branch in order to be able to create coverage reports (and also the badge). Similarly, it should start working once GitHub Actions workflow starts running in main.