### PR TITLE
Feature/38 GitHub release

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -119,7 +119,7 @@ jobs:
     name: Create GitHub Release
     needs: Docker-Integration-Test
     runs-on: ubuntu-latest
-    #if: github.ref == 'refs/heads/main' && github.event_name == 'push' #Only runs if pushing to main
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push' #Only runs if pushing to main
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -135,7 +135,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: TEST-v${{ env.version }} #will be v0.5.7 for example
-          release_name: GA4GH Starter Kit - DRS TEST-v${{ env.version }}
+          tag_name: v${{ env.version }} #will be v0.5.7 for example
+          release_name: GA4GH Starter Kit - Common v${{ env.version }}
           draft: false
-          prerelease: true
+          prerelease: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,14 +37,14 @@ jobs:
         ./gradlew jacocoTestReport
         bash <(curl -s https://codecov.io/bash)
 
-    - name: Codecov Coverage Report
-      uses: codecov/codecov-action@v2
-      with:
-        files: ./build/reports/jacoco/test/jacocoTestReport.xml # optional
-        flags: unittest #optional
-        # name: codecov-umbrella # optional
-        fail_ci_if_error: true # optional (default = false)
-        verbose: true # optional (default = false)
+    # - name: Codecov Coverage Report
+    #   uses: codecov/codecov-action@v2
+    #   with:
+    #     files: ./build/reports/jacoco/test/jacocoTestReport.xml # optional
+    #     flags: unittest #optional
+    #     # name: codecov-umbrella # optional
+    #     fail_ci_if_error: true # optional (default = false)
+    #     verbose: true # optional (default = false)
 
   Docker-Integration-Test:
     needs: Unit-Test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,15 +32,15 @@ jobs:
     - name: Running Tests
       run: "./gradlew test --tests=org.*"
 
-    # - name: After Success Submitting Code Coverage
-    #   run: | #jacocoTestReport is for testing code coverage, submits the last report to the link
-    #     ./gradlew jacocoTestReport
-    #     bash <(curl -s https://codecov.io/bash)
+    - name: After Success Submitting Code Coverage
+      run: | #jacocoTestReport is for testing code coverage, submits the last report to the link
+        ./gradlew jacocoTestReport
+        bash <(curl -s https://codecov.io/bash)
 
     - name: Codecov Coverage Report
       uses: codecov/codecov-action@v2
       with:
-        # files: ./coverage1.xml,./coverage2.xml # optional
+        files: ./build/reports # optional
         flags: unittest #optional
         # name: codecov-umbrella # optional
         fail_ci_if_error: true # optional (default = false)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Codecov Coverage Report
       uses: codecov/codecov-action@v2
       with:
-        files: ./build/reports/jacoco/test/html/jacocoTestReport.xml # optional
+        files: ./build/reports/jacoco/test/jacocoTestReport.xml # optional
         flags: unittest #optional
         # name: codecov-umbrella # optional
         fail_ci_if_error: true # optional (default = false)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,15 +38,13 @@ jobs:
     #     bash <(curl -s https://codecov.io/bash)
 
     - name: Codecov Coverage Report
-      steps:
-      - uses: actions/checkout@master
-      - uses: codecov/codecov-action@v2
-        with:
-          # files: ./coverage1.xml,./coverage2.xml # optional
-          flags: unittest #optional
-          # name: codecov-umbrella # optional
-          fail_ci_if_error: true # optional (default = false)
-          verbose: true # optional (default = false)
+    - uses: codecov/codecov-action@v2
+      with:
+        # files: ./coverage1.xml,./coverage2.xml # optional
+        flags: unittest #optional
+        # name: codecov-umbrella # optional
+        fail_ci_if_error: true # optional (default = false)
+        verbose: true # optional (default = false)
 
   Docker-Integration-Test:
     needs: Unit-Test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,17 +37,7 @@ jobs:
         ./gradlew jacocoTestReport
         bash <(curl -s https://codecov.io/bash)
 
-    # - name: Codecov Coverage Report
-    #   uses: codecov/codecov-action@v2
-    #   with:
-    #     files: ./build/reports/jacoco/test/jacocoTestReport.xml # optional
-    #     flags: unittest #optional
-    #     # name: codecov-umbrella # optional
-    #     fail_ci_if_error: true # optional (default = false)
-    #     verbose: true # optional (default = false)
-
   Docker-Integration-Test:
-    if: false
     needs: Unit-Test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,14 +37,14 @@ jobs:
         ./gradlew jacocoTestReport
         bash <(curl -s https://codecov.io/bash)
 
-    # - name: Codecov Coverage Report
-    #   uses: codecov/codecov-action@v2
-    #   with:
-    #     files: ./build/reports/jacoco/test/jacocoTestReport.xml # optional
-    #     flags: unittest #optional
-    #     # name: codecov-umbrella # optional
-    #     fail_ci_if_error: true # optional (default = false)
-    #     verbose: true # optional (default = false)
+    - name: Codecov Coverage Report
+      uses: codecov/codecov-action@v2
+      with:
+        files: ./build/reports/jacoco/test/jacocoTestReport.xml # optional
+        flags: unittest #optional
+        # name: codecov-umbrella # optional
+        fail_ci_if_error: true # optional (default = false)
+        verbose: true # optional (default = false)
 
   Docker-Integration-Test:
     needs: Unit-Test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,10 +32,10 @@ jobs:
     - name: Running Tests
       run: "./gradlew test --tests=org.*"
 
-    - name: After Success Submitting Code Coverage
-      run: | #jacocoTestReport is for testing code coverage, submits the last report to the link
-        ./gradlew jacocoTestReport
-        bash <(curl -s https://codecov.io/bash)
+    # - name: After Success Submitting Code Coverage
+    #   run: | #jacocoTestReport is for testing code coverage, submits the last report to the link
+    #     ./gradlew jacocoTestReport
+    #     bash <(curl -s https://codecov.io/bash)
 
     - name: Codecov Coverage Report
       uses: codecov/codecov-action@v2
@@ -45,7 +45,6 @@ jobs:
         # name: codecov-umbrella # optional
         fail_ci_if_error: true # optional (default = false)
         verbose: true # optional (default = false)
-        override_commit: 8bae75f
 
   Docker-Integration-Test:
     needs: Unit-Test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Codecov Coverage Report
       uses: codecov/codecov-action@v2
       with:
-        files: ./build/reports/*.xml # optional
+        files: ./build/reports/jacoco/test/html/index.html # optional
         flags: unittest #optional
         # name: codecov-umbrella # optional
         fail_ci_if_error: true # optional (default = false)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,10 +38,10 @@ jobs:
     #     bash <(curl -s https://codecov.io/bash)
     
     - name: Upload reports to Codecov
-        run: |
-          curl -Os https://uploader.codecov.io/latest/linux/codecov
-          chmod +x codecov
-          ./codecov -f coverage/codecov-result.json -Z
+      run: |
+        curl -Os https://uploader.codecov.io/latest/linux/codecov
+        chmod +x codecov
+        ./codecov -f coverage/codecov-result.json -Z
 
     # - name: Codecov Coverage Report
     #   uses: codecov/codecov-action@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,25 +32,19 @@ jobs:
     - name: Running Tests
       run: "./gradlew test --tests=org.*"
 
-    # - name: After Success Submitting Code Coverage
-    #   run: | #jacocoTestReport is for testing code coverage, submits the last report to the link
-    #     ./gradlew jacocoTestReport
-    #     bash <(curl -s https://codecov.io/bash)
-    
-    - name: Upload reports to Codecov
-      run: |
-        curl -Os https://uploader.codecov.io/latest/linux/codecov
-        chmod +x codecov
-        ./codecov -f coverage/codecov-result.json -Z
+    - name: After Success Submitting Code Coverage
+      run: | #jacocoTestReport is for testing code coverage, submits the last report to the link
+        ./gradlew jacocoTestReport
+        bash <(curl -s https://codecov.io/bash)
 
-    # - name: Codecov Coverage Report
-    #   uses: codecov/codecov-action@v2
-    #   with:
-    #     files: ./build/reports/jacoco/test/html/index.html # optional
-    #     flags: unittest #optional
-    #     # name: codecov-umbrella # optional
-    #     fail_ci_if_error: true # optional (default = false)
-    #     verbose: true # optional (default = false)
+    - name: Codecov Coverage Report
+      uses: codecov/codecov-action@v2
+      with:
+        files: ./build/reports/jacoco/test/html/jacocoTestReport.xml # optional
+        flags: unittest #optional
+        # name: codecov-umbrella # optional
+        fail_ci_if_error: true # optional (default = false)
+        verbose: true # optional (default = false)
 
   Docker-Integration-Test:
     needs: Unit-Test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,3 +114,28 @@ jobs:
         build-args: VERSION=${{ env.version }}
         cache-from: type=gha #GitHub Actions Cache Exporter
         cache-to: type=gha,mode=max
+  
+  build:
+    name: Create GitHub Release
+    needs: Docker-Integration-Test
+    runs-on: ubuntu-latest
+    #if: github.ref == 'refs/heads/main' && github.event_name == 'push' #Only runs if pushing to main
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Get and Set Version
+        run: |
+          source ci/set-docker-image-version.sh
+          echo "version=${DOCKER_IMG_VER}" >> $GITHUB_ENV
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: TEST-v${{ env.version }} #will be v0.5.7 for example
+          release_name: GA4GH Starter Kit - DRS TEST-v${{ env.version }}
+          draft: false
+          prerelease: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,14 +37,14 @@ jobs:
         ./gradlew jacocoTestReport
         bash <(curl -s https://codecov.io/bash)
 
-    - name: Codecov Coverage Report
-      uses: codecov/codecov-action@v2
-      with:
-        files: ./build/reports/jacoco/test/html/index.html # optional
-        flags: unittest #optional
-        # name: codecov-umbrella # optional
-        fail_ci_if_error: true # optional (default = false)
-        verbose: true # optional (default = false)
+    # - name: Codecov Coverage Report
+    #   uses: codecov/codecov-action@v2
+    #   with:
+    #     files: ./build/reports/jacoco/test/html/index.html # optional
+    #     flags: unittest #optional
+    #     # name: codecov-umbrella # optional
+    #     fail_ci_if_error: true # optional (default = false)
+    #     verbose: true # optional (default = false)
 
   Docker-Integration-Test:
     needs: Unit-Test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,10 +32,16 @@ jobs:
     - name: Running Tests
       run: "./gradlew test --tests=org.*"
 
-    - name: After Success Submitting Code Coverage
-      run: | #jacocoTestReport is for testing code coverage, submits the last report to the link
-        ./gradlew jacocoTestReport
-        bash <(curl -s https://codecov.io/bash)
+    # - name: After Success Submitting Code Coverage
+    #   run: | #jacocoTestReport is for testing code coverage, submits the last report to the link
+    #     ./gradlew jacocoTestReport
+    #     bash <(curl -s https://codecov.io/bash)
+    
+    - name: Upload reports to Codecov
+        run: |
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          chmod +x codecov
+          ./codecov -f coverage/codecov-result.json -Z
 
     # - name: Codecov Coverage Report
     #   uses: codecov/codecov-action@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Codecov Coverage Report
       uses: codecov/codecov-action@v2
       with:
-        files: ./build/reports # optional
+        files: ./build/reports/*.xml # optional
         flags: unittest #optional
         # name: codecov-umbrella # optional
         fail_ci_if_error: true # optional (default = false)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,10 +32,10 @@ jobs:
     - name: Running Tests
       run: "./gradlew test --tests=org.*"
 
-    # - name: After Success Submitting Code Coverage
-    #   run: | #jacocoTestReport is for testing code coverage, submits the last report to the link
-    #     ./gradlew jacocoTestReport
-    #     bash <(curl -s https://codecov.io/bash)
+    - name: After Success Submitting Code Coverage
+      run: | #jacocoTestReport is for testing code coverage, submits the last report to the link
+        ./gradlew jacocoTestReport
+        bash <(curl -s https://codecov.io/bash)
 
     - name: Codecov Coverage Report
       uses: codecov/codecov-action@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
     #     bash <(curl -s https://codecov.io/bash)
 
     - name: Codecov Coverage Report
-    - uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v2
       with:
         # files: ./coverage1.xml,./coverage2.xml # optional
         flags: unittest #optional

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,16 +37,17 @@ jobs:
         ./gradlew jacocoTestReport
         bash <(curl -s https://codecov.io/bash)
 
-    - name: Codecov Coverage Report
-      uses: codecov/codecov-action@v2
-      with:
-        files: ./build/reports/jacoco/test/jacocoTestReport.xml # optional
-        flags: unittest #optional
-        # name: codecov-umbrella # optional
-        fail_ci_if_error: true # optional (default = false)
-        verbose: true # optional (default = false)
+    # - name: Codecov Coverage Report
+    #   uses: codecov/codecov-action@v2
+    #   with:
+    #     files: ./build/reports/jacoco/test/jacocoTestReport.xml # optional
+    #     flags: unittest #optional
+    #     # name: codecov-umbrella # optional
+    #     fail_ci_if_error: true # optional (default = false)
+    #     verbose: true # optional (default = false)
 
   Docker-Integration-Test:
+    if: false
     needs: Unit-Test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,10 +32,21 @@ jobs:
     - name: Running Tests
       run: "./gradlew test --tests=org.*"
 
-    - name: After Success Submitting Code Coverage
-      run: | #jacocoTestReport is for testing code coverage, submits the last report to the link
-        ./gradlew jacocoTestReport
-        bash <(curl -s https://codecov.io/bash)
+    # - name: After Success Submitting Code Coverage
+    #   run: | #jacocoTestReport is for testing code coverage, submits the last report to the link
+    #     ./gradlew jacocoTestReport
+    #     bash <(curl -s https://codecov.io/bash)
+
+    - name: Codecov Coverage Report
+      steps:
+      - uses: actions/checkout@master
+      - uses: codecov/codecov-action@v2
+        with:
+          # files: ./coverage1.xml,./coverage2.xml # optional
+          flags: unittest #optional
+          # name: codecov-umbrella # optional
+          fail_ci_if_error: true # optional (default = false)
+          verbose: true # optional (default = false)
 
   Docker-Integration-Test:
     needs: Unit-Test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,7 @@ jobs:
         # name: codecov-umbrella # optional
         fail_ci_if_error: true # optional (default = false)
         verbose: true # optional (default = false)
+        override_commit: 8bae75f
 
   Docker-Integration-Test:
     needs: Unit-Test

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Java 11+](https://img.shields.io/badge/java-11+-blue.svg?style=flat-square)](https://www.java.com)
 [![Gradle 7.3.3+](https://img.shields.io/badge/gradle-7.3.3+-blue.svg?style=flat-square)](https://gradle.org/)
 [![GitHub Actions](https://img.shields.io/github/workflow/status/ga4gh/ga4gh-starter-kit-common/Standard%20Tests/main)](https://github.com/ga4gh/ga4gh-starter-kit-common/actions)
-![Codecov](https://img.shields.io/codecov/c/github/ga4gh/ga4gh-starter-kit-common?style=flat-square)
+[![Codecov](https://img.shields.io/codecov/c/github/ga4gh/ga4gh-starter-kit-common?style=flat-square)](https://app.codecov.io/gh/ga4gh/ga4gh-starter-kit-common)
 
 # GA4GH Starter Kit Common
 Common utils library for GA4GH Starter Kit web services


### PR DESCRIPTION
Similar to [#54](https://github.com/ga4gh/ga4gh-starter-kit-drs/issues/54), creates a GitHub release when pushing to main. Gets the version number to accurately name and tag the release.